### PR TITLE
Add Support for Bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
-bevy_asset = { version = "0.6", default-features = false }
-bevy_ecs = { version = "0.6", default-features = false }
-bevy_log = { version = "0.6", default-features = false, optional = true }
-bevy_math = { version = "0.6", default-features = false }
-bevy_render = { version = "0.6", default-features = false }
-bevy_sprite = { version = "0.6", default-features = false }
+bevy_asset = { version = "0.7", default-features = false }
+bevy_ecs = { version = "0.7", default-features = false }
+bevy_log = { version = "0.7", default-features = false, optional = true }
+bevy_math = { version = "0.7", default-features = false }
+bevy_render = { version = "0.7", default-features = false }
+bevy_sprite = { version = "0.7", default-features = false }
+bevy_utils = { version = "0.7", default-features = false }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-bevy = "0.6"
+bevy = "0.7"
 
 [features]
 default = ["debug"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This crate is essentially an augmentation of Bevy's own  `TextureAtlasBuilder`. 
 Add to your `[dependencies]` list in `Cargo.toml`:
 
 ```toml
-bevy_tile_atlas = "0.2.0"
+bevy_tile_atlas = "0.3.0"
 ```
 
 ## Usage
@@ -57,7 +57,8 @@ fn build_tileset(handles: Vec<Handle<Image>>, textures: &mut Assets<Image>) -> T
 ## Bevy Compatibility
 
 | bevy | bevy_tile_atlas |
-| ---- | --------------- |
+|------|-----------------|
+| 0.7  | 0.3.0           |
 | 0.6  | 0.2.0           |
 | 0.5  | 0.1.4           |
 

--- a/src/tile_atlas.rs
+++ b/src/tile_atlas.rs
@@ -6,7 +6,7 @@ use bevy_math::Vec2;
 use bevy_render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use bevy_render::texture::{Image, TextureFormatPixelInfo};
 use bevy_sprite::{Rect, TextureAtlas, TextureAtlasBuilderError};
-use std::collections::HashMap;
+use bevy_utils::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -62,6 +62,8 @@ impl TileAtlasBuilder {
 	/// # Examples
 	///
 	/// ```
+	/// use bevy::prelude::*;
+	/// use bevy_tile_atlas::TileAtlasBuilder;
 	/// let mut builder = TileAtlasBuilder::new(Vec2::new(32.0, 32.0));
 	/// ```
 	pub fn new(tile_size: Vec2) -> Self {
@@ -86,8 +88,10 @@ impl TileAtlasBuilder {
 	/// # Examples
 	///
 	/// ```
+	/// use bevy::prelude::*;
+	/// use bevy_tile_atlas::TileAtlasBuilder;
 	/// // Auto-size
-	///	let mut builder = TileAtlasBuilder::default();
+	/// let mut builder = TileAtlasBuilder::default();
 	/// // Fixed-size
 	/// let mut builder = builder.tile_size(Some(Vec2::new(32.0, 32.0)));
 	/// // Back to auto-size


### PR DESCRIPTION
This PR adds support for the recently released Bevy 0.7 version.

## Changes

This does not contain any user-facing changes— all changes were internal.

* Added `bevy_utils` dependency
  * Replace usage of `std::collections::HashMap` with `bevy_utils::HashMap` in `TileAtlasBuilder`