### PR TITLE
Update to bevy 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"
@@ -11,17 +11,17 @@ readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
-bevy_asset = { version = "0.7", default-features = false }
-bevy_ecs = { version = "0.7", default-features = false }
-bevy_log = { version = "0.7", default-features = false, optional = true }
-bevy_math = { version = "0.7", default-features = false }
-bevy_render = { version = "0.7", default-features = false }
-bevy_sprite = { version = "0.7", default-features = false }
-bevy_utils = { version = "0.7", default-features = false }
+bevy_asset = { version = "0.8", default-features = false }
+bevy_ecs = { version = "0.8", default-features = false }
+bevy_log = { version = "0.8", default-features = false, optional = true }
+bevy_math = { version = "0.8", default-features = false }
+bevy_render = { version = "0.8", default-features = false }
+bevy_sprite = { version = "0.8", default-features = false }
+bevy_utils = { version = "0.8", default-features = false }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-bevy = "0.7"
+bevy = "0.8"
 
 [features]
 default = ["debug"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This crate is essentially an augmentation of Bevy's own  `TextureAtlasBuilder`. 
 Add to your `[dependencies]` list in `Cargo.toml`:
 
 ```toml
-bevy_tile_atlas = "0.3.0"
+bevy_tile_atlas = "0.4.0"
 ```
 
 ## Usage
@@ -58,6 +58,7 @@ fn build_tileset(handles: Vec<Handle<Image>>, textures: &mut Assets<Image>) -> T
 
 | bevy | bevy_tile_atlas |
 |------|-----------------|
+| 0.8  | 0.4.0           |
 | 0.7  | 0.3.0           |
 | 0.6  | 0.2.0           |
 | 0.5  | 0.1.4           |

--- a/examples/atlas.rs
+++ b/examples/atlas.rs
@@ -20,7 +20,7 @@ fn main() {
 		.init_resource::<TileHandles>()
 		.init_resource::<MyAtlas>()
 		.add_state(AppState::LoadTileset)
-		.add_system_set(SystemSet::on_update(AppState::LoadTileset).with_system(load_tiles))
+		.add_system_set(SystemSet::on_enter(AppState::LoadTileset).with_system(load_tiles))
 		.add_system_set(SystemSet::on_update(AppState::CreateTileset).with_system(create_atlas))
 		.add_system_set(SystemSet::on_enter(AppState::DisplayTileset).with_system(display_atlas))
 		.run();
@@ -54,7 +54,7 @@ fn load_tiles(
 		asset_server.load_untyped("tiles/grass.png"),
 	];
 	handles.0 = tiles;
-	state.set(AppState::CreateTileset).unwrap();
+	state.overwrite_set(AppState::CreateTileset).unwrap();
 }
 
 fn create_atlas(

--- a/examples/atlas.rs
+++ b/examples/atlas.rs
@@ -20,7 +20,7 @@ fn main() {
 		.init_resource::<TileHandles>()
 		.init_resource::<MyAtlas>()
 		.add_state(AppState::LoadTileset)
-		.add_system_set(SystemSet::on_enter(AppState::LoadTileset).with_system(load_tiles))
+		.add_system_set(SystemSet::on_update(AppState::LoadTileset).with_system(load_tiles))
 		.add_system_set(SystemSet::on_update(AppState::CreateTileset).with_system(create_atlas))
 		.add_system_set(SystemSet::on_enter(AppState::DisplayTileset).with_system(display_atlas))
 		.run();
@@ -74,7 +74,7 @@ fn create_atlas(
 	let mut is_first = true;
 
 	for handle in &handles.0 {
-		if let Some(texture) = textures.get(handle) {
+		if let Some(texture) = textures.get(&handle.typed_weak()) {
 			if let Ok(index) = builder.add_texture(handle.clone().typed::<Image>(), texture) {
 				println!("Added texture at index: {}", index);
 			}
@@ -98,7 +98,7 @@ fn display_atlas(
 	mut commands: Commands,
 	mut atlases: ResMut<Assets<TextureAtlas>>,
 ) {
-	commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+	commands.spawn_bundle(Camera2dBundle::default());
 
 	let atlas = atlas_res.0.take().unwrap();
 	let handle = atlas.texture.clone();

--- a/src/store.rs
+++ b/src/store.rs
@@ -23,7 +23,7 @@ impl TextureStore for Assets<Image> {
 	}
 
 	fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&Image> {
-		self.get(handle)
+		self.get(&Handle::weak(handle.into()))
 	}
 }
 


### PR DESCRIPTION
@MrGVSV I hope you don't mind me updating this library to work with bevy 0.8

Except for updating dependencies.
Because of [this change](https://github.com/bevyengine/bevy/commit/1bbd5c25c0e53c51ac4a3bc1dc46fd2f35e72883) in bevy_asset crate, there was one small update that needed to be made to library code.

I have needed to do some changes to example.