### PR TITLE
Update to bevy 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"
@@ -11,17 +11,17 @@ readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
-bevy_asset = { version = "0.8", default-features = false }
-bevy_ecs = { version = "0.8", default-features = false }
-bevy_log = { version = "0.8", default-features = false, optional = true }
-bevy_math = { version = "0.8", default-features = false }
-bevy_render = { version = "0.8", default-features = false }
-bevy_sprite = { version = "0.8", default-features = false }
-bevy_utils = { version = "0.8", default-features = false }
+bevy_asset = { version = "0.9", default-features = false }
+bevy_ecs = { version = "0.9", default-features = false }
+bevy_log = { version = "0.9", default-features = false, optional = true }
+bevy_math = { version = "0.9", default-features = false }
+bevy_render = { version = "0.9", default-features = false }
+bevy_sprite = { version = "0.9", default-features = false }
+bevy_utils = { version = "0.9", default-features = false }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-bevy = "0.8"
+bevy = "0.9"
 
 [features]
 default = ["debug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.5.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"

--- a/examples/atlas.rs
+++ b/examples/atlas.rs
@@ -34,11 +34,11 @@ enum AppState {
 }
 
 /// The resultant atlas (or `None` if not yet generated)
-#[derive(Default)]
+#[derive(Resource, Default)]
 struct MyAtlas(Option<TextureAtlas>);
 
 /// Contains the list of handles we need to be loaded before we can build the atlas
-#[derive(Default)]
+#[derive(Resource, Default)]
 struct TileHandles(Vec<HandleUntyped>);
 
 fn load_tiles(
@@ -98,14 +98,14 @@ fn display_atlas(
 	mut commands: Commands,
 	mut atlases: ResMut<Assets<TextureAtlas>>,
 ) {
-	commands.spawn_bundle(Camera2dBundle::default());
+	commands.spawn(Camera2dBundle::default());
 
 	let atlas = atlas_res.0.take().unwrap();
 	let handle = atlas.texture.clone();
 	let atlas_handle = atlases.add(atlas);
 
 	// Display the third tile (Wall)
-	commands.spawn_bundle(SpriteSheetBundle {
+	commands.spawn(SpriteSheetBundle {
 		transform: Transform {
 			translation: Vec3::new(0.0, 48.0, 0.0),
 			..Default::default()
@@ -116,7 +116,7 @@ fn display_atlas(
 	});
 
 	// Display the whole tileset
-	commands.spawn_bundle(SpriteBundle {
+	commands.spawn(SpriteBundle {
 		texture: handle,
 		..Default::default()
 	});

--- a/src/tile_atlas.rs
+++ b/src/tile_atlas.rs
@@ -2,10 +2,10 @@
 
 use crate::TextureStore;
 use bevy_asset::Handle;
-use bevy_math::Vec2;
+use bevy_math::{Rect, Vec2};
 use bevy_render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use bevy_render::texture::{Image, TextureFormatPixelInfo};
-use bevy_sprite::{Rect, TextureAtlas, TextureAtlasBuilderError};
+use bevy_sprite::{TextureAtlas, TextureAtlasBuilderError};
 use bevy_utils::HashMap;
 use thiserror::Error;
 


### PR DESCRIPTION
Quick and simple update to Bevy 0.9 so that I can update bevy_tileset.
Adds the Resource derives and changes calls to spawn_bundle to use spawn instead.