### PR TITLE
Update to work with bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"
@@ -11,17 +11,17 @@ readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
-bevy_asset = { version = "0.12", default-features = false }
-bevy_ecs = { version = "0.12", default-features = false }
-bevy_log = { version = "0.12", default-features = false, optional = true }
-bevy_math = { version = "0.12", default-features = false }
-bevy_render = { version = "0.12", default-features = false }
-bevy_sprite = { version = "0.12", default-features = false }
-bevy_utils = { version = "0.12", default-features = false }
+bevy_asset = { version = "0.13", default-features = false }
+bevy_ecs = { version = "0.13", default-features = false }
+bevy_log = { version = "0.13", default-features = false, optional = true }
+bevy_math = { version = "0.13", default-features = false }
+bevy_render = { version = "0.13", default-features = false }
+bevy_sprite = { version = "0.13", default-features = false }
+bevy_utils = { version = "0.13", default-features = false }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-bevy = "0.12"
+bevy = "0.13"
 
 [features]
 default = ["debug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tile_atlas"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "A TextureAtlas builder for ordered tilesets"
@@ -11,17 +11,17 @@ readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
-bevy_asset = { version = "0.11", default-features = false }
-bevy_ecs = { version = "0.11", default-features = false }
-bevy_log = { version = "0.11", default-features = false, optional = true }
-bevy_math = { version = "0.11", default-features = false }
-bevy_render = { version = "0.11", default-features = false }
-bevy_sprite = { version = "0.11", default-features = false }
-bevy_utils = { version = "0.11", default-features = false }
+bevy_asset = { version = "0.12", default-features = false }
+bevy_ecs = { version = "0.12", default-features = false }
+bevy_log = { version = "0.12", default-features = false, optional = true }
+bevy_math = { version = "0.12", default-features = false }
+bevy_render = { version = "0.12", default-features = false }
+bevy_sprite = { version = "0.12", default-features = false }
+bevy_utils = { version = "0.12", default-features = false }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-bevy = "0.11"
+bevy = "0.12"
 
 [features]
 default = ["debug"]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 //! Defines the `TextureStore` trait which is used by `TileAtlasBuilder` to manage its textures
 
-use bevy_asset::{Assets, Handle, HandleId};
+use bevy_asset::{Assets, Handle};
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_render::texture::Image;
 use std::ops::{Deref, DerefMut};
@@ -14,25 +14,17 @@ pub trait TextureStore {
 	/// Add a texture to the store
 	fn add(&mut self, asset: Image) -> Handle<Image>;
 	/// Get a texture from the store
-	fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&Image>;
+	fn get<H: Into<Handle<Image>>>(&self, handle: H) -> Option<&Image>;
 }
 
 impl TextureStore for Assets<Image> {
-	fn add(&mut self, asset: Image) -> Handle<Image> {
-		self.add(asset)
-	}
+	fn add(&mut self, asset: Image) -> Handle<Image> { self.add(asset) }
 
-	fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&Image> {
-		self.get(&Handle::weak(handle.into()))
-	}
+	fn get<H: Into<Handle<Image>>>(&self, handle: H) -> Option<&Image> { self.get(handle.into()) }
 }
 
 impl<'w, T: TextureStore + Resource> TextureStore for ResMut<'w, T> {
-	fn add(&mut self, asset: Image) -> Handle<Image> {
-		self.deref_mut().add(asset)
-	}
+	fn add(&mut self, asset: Image) -> Handle<Image> { self.deref_mut().add(asset) }
 
-	fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&Image> {
-		self.deref().get(handle)
-	}
+	fn get<H: Into<Handle<Image>>>(&self, handle: H) -> Option<&Image> { self.deref().get(handle) }
 }

--- a/src/tile_atlas.rs
+++ b/src/tile_atlas.rs
@@ -3,15 +3,20 @@
 use crate::TextureStore;
 use bevy_asset::Handle;
 use bevy_math::{Rect, Vec2};
-use bevy_render::render_resource::{Extent3d, TextureDimension, TextureFormat};
-use bevy_render::texture::{Image, TextureFormatPixelInfo};
+use bevy_render::{
+	render_resource::{Extent3d, TextureDimension, TextureFormat},
+	texture::{Image, TextureFormatPixelInfo},
+};
 use bevy_sprite::{TextureAtlas, TextureAtlasBuilderError};
 use bevy_utils::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum TileAtlasBuilderError {
-	#[error("the given tile does not match the current tile size (expected {expected:?}, found {found:?})")]
+	#[error(
+		"the given tile does not match the current tile size (expected {expected:?}, found \
+		 {found:?})"
+	)]
 	InvalidTileSize { expected: Vec2, found: Vec2 },
 	#[error("the atlas does not contain any tiles")]
 	EmptyAtlas,
@@ -127,21 +132,15 @@ impl TileAtlasBuilder {
 	}
 
 	/// Gets the current tile size (if any)
-	pub fn get_tile_size(&self) -> Option<Vec2> {
-		self.tile_size
-	}
+	pub fn get_tile_size(&self) -> Option<Vec2> { self.tile_size }
 
 	/// Gets the current maximum number of columns
 	///
 	/// If the columns property was not set, this will equal the number of added textures
-	pub fn get_max_columns(&self) -> usize {
-		self.max_columns.unwrap_or(self.handles.len())
-	}
+	pub fn get_max_columns(&self) -> usize { self.max_columns.unwrap_or(self.handles.len()) }
 
 	/// Gets the current number of added textures
-	pub fn len(&self) -> usize {
-		self.handles.len()
-	}
+	pub fn len(&self) -> usize { self.handles.len() }
 
 	/// Adds a texture to be copied to the texture atlas.
 	///
@@ -173,8 +172,10 @@ impl TileAtlasBuilder {
 				);
 				#[cfg(feature = "debug")]
 				bevy_log::warn!(
-					"The given texture does not fit into specified tile size (expected: {:?}, found: {:?}). Skipping...",
-					expected, found,
+					"The given texture does not fit into specified tile size (expected: {:?}, \
+					 found: {:?}). Skipping...",
+					expected,
+					found,
 				);
 				return Err(TileAtlasBuilderError::InvalidTileSize { expected, found });
 			}
@@ -220,7 +221,7 @@ impl TileAtlasBuilder {
 		let mut texture_handles = HashMap::default();
 		let mut texture_rects = Vec::with_capacity(total);
 		for (index, handle) in self.handles.iter().enumerate() {
-			let texture = textures.get(handle).unwrap();
+			let texture = textures.get(handle.clone()).unwrap();
 			let x = (col_idx as f32) * tile_size.x;
 			let y = (row_idx as f32) * tile_size.y;
 			let min = Vec2::new(x, y);


### PR DESCRIPTION
This isn't perfect, due to bevy's changes to TextureAtlas, but it works.

The API is now changed on finish to return the texture handle and the layout.

To use this today, update your Cargo.toml to this:

```
bevy_tile_atlas = { git = "https://github.com/j-t-d/bevy_tile_atlas.git", rev = "b5318c6"}
```